### PR TITLE
Add HoloLens2 OS build requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ File/folder  | Description |
 2. Install the [recommended Unity version](https://learn.microsoft.com/en-us/windows/mixed-reality/develop/unity/choosing-unity-version) 
 
 This repo uses following versions of tools
+* HoloLens 2 with OS build minimum 20348.1537
 * Unity 2020.3.40f1
 * Mixed Reality OpenXR Plugin 1.5.1
 * Visual Studio 2022 17.3.6


### PR DESCRIPTION
HoloLens 2 OS build number should be at least `20348.1537` to make the extended eye tracking features work.